### PR TITLE
FIX "Send connection offer" button disappearing in small screen

### DIFF
--- a/python/view/index.html
+++ b/python/view/index.html
@@ -110,13 +110,8 @@
 
 
             <nav class="navbar navbar-expand-lg navbar-light bg-light" style="margin-top:2em;">
-              <a class="h3 navbar-brand" href="#">Pending Connections</a>
-              <div class="collapse navbar-collapse" id="navbarSupportedContent">
-                <ul class="navbar-nav mr-auto">
-
-                </ul>
-                <button type="button" class="btn btn-outline-primary btn-small navbar-btn" data-toggle="modal" data-target="#send_req_modal">Send connection offer</button>
-              </div>
+              <a class="h3 navbar-brand mr-auto" href="#">Pending Connections</a>
+              <button type="button" class="btn btn-outline-primary btn-small navbar-btn" data-toggle="modal" data-target="#send_req_modal">Send connection offer</button>
             </nav>
 
 
@@ -149,11 +144,6 @@
 
             <nav class="navbar navbar-expand-lg navbar-light bg-light">
               <a class="h3 navbar-brand" href="#">Pairwise Connections</a>
-              <div class="collapse navbar-collapse" id="navbarSupportedContent">
-                <ul class="navbar-nav mr-auto">
-
-                </ul>
-              </div>
             </nav>
 
             <table class="table table-bordered">


### PR DESCRIPTION
FIX that if the screen (or browser window) is medium or smaller, the "Send connection offer" button disappear. 

In my first usage of the demo, I had opened 2 two browsers windows, side by side, to simultaneously see the 2 agents, and the "Send connection offer" button was not visible.