### PR TITLE
Tests for updated connection protocol

### DIFF
--- a/test-suite/conftest.py
+++ b/test-suite/conftest.py
@@ -120,6 +120,11 @@ async def transport(config, event_loop, logger):
     event_loop.create_task(transport.start_server())
     return transport
 
+@pytest.fixture(scope='session')
+async def connection(config, wallet_handle, transport):
+    from tests.connection.manual import get_connection_started_by_suite
+
+    yield await get_connection_started_by_suite(config, wallet_handle, transport)
 
 ### Test configuration loading ###
 

--- a/test-suite/tests/__init__.py
+++ b/test-suite/tests/__init__.py
@@ -95,7 +95,7 @@ async def sign_field(wallet_handle, my_vk, field_value):
         await crypto.crypto_sign(
             wallet_handle,
             my_vk,
-            result["sig_data"]
+            sig_data
         )
     ).decode('utf-8')
 

--- a/test-suite/tests/__init__.py
+++ b/test-suite/tests/__init__.py
@@ -2,10 +2,12 @@
 """
 import base64
 import json
+import time
+import struct
 import asyncio
 import pytest
 from pytest import fail
-from typing import Callable
+from typing import Callable, Any
 from indy import crypto
 
 from message import Message
@@ -30,11 +32,17 @@ async def expect_message(transport: BaseTransport, timeout: int):
 
     fail("No message received before timing out; tested agent failed to respond")
 
-def validate_message(expected_attrs: [str], msg: Message):
+def validate_message(expected_attrs: [Any], msg: Message):
     __tracebackhide__ = True
     for attribute in expected_attrs:
-        if attribute not in msg:
-            fail("Attribute \"{}\" is missing from msg:\n{}".format(attribute, msg))
+        if isinstance(attribute, tuple):
+            assert attribute[0] in msg, \
+                'Attribute "{}" is missing from message: \n{}'.format(attribute[0], msg)
+            assert msg[attribute[0]] == attribute[1], \
+                'Message.{} != {}'.format(attribute[0], attribute[1])
+        else:
+            assert attribute in msg, \
+                'Attribute "{}" is missing from message: \n{}'.format(attribute, msg)
 
 async def pack(wallet_handle: int, my_vk: str, their_vk: str, msg: Message) -> bytes:
     return await crypto.pack_message(
@@ -55,9 +63,45 @@ async def unpack(wallet_handle: int, wire_msg_bytes: bytes, **kwargs) -> Message
     )
 
     if 'expected_to_vk' in kwargs:
-        assert kwargs['expected_to_vk'] == wire_msg['recipient_verkey'], 'Message is not for the expected verkey!'
+        assert kwargs['expected_to_vk'] == wire_msg['recipient_verkey'], \
+            'Message is not for the expected verkey!'
 
     if 'expected_from_vk' in kwargs:
-        assert kwargs['expected_from_vk'] == wire_msg['sender_verkey'], 'Message is not from the expected verkey!'
+        assert kwargs['expected_from_vk'] == wire_msg['sender_verkey'], \
+            'Message is not from the expected verkey!'
 
     return Serializer.unpack(wire_msg['message'])
+
+async def unpack_and_verify_signed_field(signed_field):
+    signature_bytes = base64.urlsafe_b64decode(signed_field['signature'].encode('utf-8'))
+    assert await crypto.crypto_verify(
+        signed_field['signer'],
+        signed_field['sig_data'],
+        signature_bytes
+    ), "Signature verification failed on field {}!".format(signed_field)
+    data_bytes = base64.urlsafe_b64decode(signed_field['sig_data'])
+    timestamp = struct.unpack(">Q", data_bytes[:8])
+    fieldjson = data_bytes[8:]
+    return json.loads(fieldjson)
+
+async def sign_field(wallet_handle, my_vk, field_value):
+    timestamp_bytes = struct.pack(">Q", int(time.time()))
+
+    sig_data = base64.urlsafe_b64encode(
+        timestamp_bytes + json.dumps(field_value).encode()
+    ).decode('utf-8')
+
+    signature = base64.urlsafe_b64encode(
+        await crypto.crypto_sign(
+            wallet_handle,
+            my_vk,
+            result["sig_data"]
+        )
+    ).decode('utf-8')
+
+    return {
+        "@type": "did:sov:BzCbsNYhMrjHiqZDTUASHg;spec/signature/1.0/ed25519Sha512_single",
+        "sig_data": sig_data,
+        "signer": my_vk,
+        "signature": signature
+    }

--- a/test-suite/tests/connection/__init__.py
+++ b/test-suite/tests/connection/__init__.py
@@ -1,0 +1,147 @@
+import re
+import base64
+
+from serializer import JSONSerializer as Serializer
+from message import Message
+from tests import validate_message
+
+class Connection:
+    class Message:
+        FAMILY_NAME = "connections"
+        VERSION = "1.0"
+        FAMILY = "did:sov:BzCbsNYhMrjHiqZDTUASHg;spec/" + FAMILY_NAME + "/" + VERSION + "/"
+
+        INVITE = FAMILY + "invite"
+        REQUEST = FAMILY + "request"
+        RESPONSE = FAMILY + "response"
+
+    class Invite:
+        @staticmethod
+        def parse(invite_url: str) -> Message:
+            matches = re.match('(.+)?c_i=(.+)', invite_url)
+            assert matches, 'Improperly formatted invite url!'
+
+            invite_msg = Serializer.unpack(
+                base64.urlsafe_b64decode(matches.group(2)).decode('utf-8')
+            )
+
+            validate_message(
+                [
+                    ('@type', Connection.Message.INVITE),
+                    'label',
+                    'recipient_keys',
+                    'serviceEndpoint'
+                ],
+                invite_msg
+            )
+
+            return invite_msg
+
+    class Request:
+        @staticmethod
+        def build(label: str, my_did: str, my_vk: str, endpoint: str) -> Message:
+            return Message({
+                '@type': Connection.Message.REQUEST,
+                'label': label,
+                'connection': {
+                    'DID': my_did,
+                    'DIDDoc': {
+                        "@context": "https://w3id.org/did/v1",
+                        "publicKey": [{
+                            "id": my_did + "#keys-1",
+                            "type": "Ed25519VerificationKey2018",
+                            "controller": my_did,
+                            "publicKeyBase58": my_vk
+                        }],
+                        "service": [{
+                            "type": "IndyAgent",
+                            "recipient_keys": [my_vk],
+                            #"routing_keys": ["<example-agency-verkey>"],
+                            "serviceEndpoint": endpoint,
+                        }],
+                    }
+                }
+            })
+
+    class Response:
+        @staticmethod
+        def build(my_did: str, my_vk: str, endpoint: str) -> Message:
+            return Message({
+                '@type': Connection.Message.RESPONSE,
+                'connection': {
+                    'DID': my_did,
+                    'DIDDoc': {
+                        "@context": "https://w3id.org/did/v1",
+                        "publicKey": [{
+                            "id": my_did + "#keys-1",
+                            "type": "Ed25519VerificationKey2018",
+                            "controller": my_did,
+                            "publicKeyBase58": my_vk
+                        }],
+                        "service": [{
+                            "type": "IndyAgent",
+                            "recipient_keys": [my_vk],
+                            #"routing_keys": ["<example-agency-verkey>"],
+                            "serviceEndpoint": endpoint,
+                        }],
+                    }
+                }
+            })
+
+        @staticmethod
+        def validate_pre_sig(response: Message):
+            validate_message(
+                [
+                    ('@type', Connection.Message.RESPONSE),
+                    'connection~sig'
+                ],
+                response
+            )
+
+        @staticmethod
+        def validate(response: Message):
+            validate_message(
+                [
+                    ('@type', Connection.Message.RESPONSE),
+                    'connection'
+                ],
+                response
+            )
+
+            validate_message(
+                [
+                    'DID',
+                    'DIDDoc'
+                ],
+                response['connection']
+            )
+
+            validate_message(
+                [
+                    '@context',
+                    'publicKey',
+                    'service'
+                ],
+                response['connection']['DIDDoc']
+            )
+
+            for publicKeyBlock in response['connection']['DIDDoc']['publicKey']:
+                validate_message(
+                    [
+                        'id',
+                        'type',
+                        'controller',
+                        'publicKeyBase58'
+                    ],
+                    publicKeyBlock
+                )
+
+            for serviceBlock in response['connection']['DIDDoc']['service']:
+                validate_message(
+                    [
+                        ('type', 'IndyAgent'),
+                        'recipient_keys',
+                        'serviceEndpoint'
+                    ],
+                    serviceBlock
+                )

--- a/test-suite/tests/connection/manual.py
+++ b/test-suite/tests/connection/manual.py
@@ -47,8 +47,7 @@ async def test_connection_started_by_tested_agent(config, wallet_handle, transpo
 
     Connection.Response.validate(response)
 
-@pytest.mark.asyncio
-async def test_connection_started_by_suite(config, wallet_handle, transport):
+async def get_connection_started_by_suite(config, wallet_handle, transport):
     connection_key = await did.create_key(wallet_handle, '{}')
 
     invite_str = Connection.Invite.build(connection_key, config.endpoint)
@@ -83,3 +82,15 @@ async def test_connection_started_by_suite(config, wallet_handle, transport):
             response
         )
     )
+
+    return {
+        'my_did': my_did,
+        'my_vk': my_vk,
+        'their_did': their_did,
+        'their_vk': their_vk,
+        'their_endpoint': their_endpoint
+    }
+
+@pytest.mark.asyncio
+async def test_connection_started_by_suite(config, wallet_handle, transport):
+    await get_connection_started_by_suite(config, wallet_handle, transport)

--- a/test-suite/tests/connection/manual.py
+++ b/test-suite/tests/connection/manual.py
@@ -1,63 +1,33 @@
 import asyncio
 import pytest
-import re
-import base64
 from message import Message
-from serializer import JSONSerializer as Serializer
-from tests import expect_message, validate_message, pack, unpack
+from tests import expect_message, validate_message, pack, unpack, unpack_and_verify_signed_field
 from indy import did
-
-class Connection:
-
-    FAMILY_NAME = "connections"
-    VERSION = "1.0"
-    FAMILY = "did:sov:BzCbsNYhMrjHiqZDTUASHg;spec/" + FAMILY_NAME + "/" + VERSION + "/"
-
-    INVITE = FAMILY + "invite"
-    REQUEST = FAMILY + "request"
-    RESPONSE = FAMILY + "response"
+from . import Connection
 
 @pytest.mark.asyncio
 async def test_connection_started_by_tested_agent(config, wallet_handle, transport):
     invite_url = input('Input generated connection invite: ')
 
-    matches = re.match('(.+)?c_i=(.+)', invite_url)
-    assert matches, 'Improperly formatted invite url!'
-
-    invite_msg = Serializer.unpack(
-        base64.urlsafe_b64decode(matches.group(2)).decode('utf-8')
-    )
-
-    validate_message(
-        [
-            '@type',
-            'label',
-            'key',
-            'endpoint'
-        ],
-        invite_msg
-    )
+    invite_msg = Connection.Invite.parse(invite_url)
 
     # Create my information for connection
     (my_did, my_vk) = await did.create_and_store_my_did(wallet_handle, '{}')
 
     # Send Connection Request to inviter
-    request = Message({
-        '@type': Connection.REQUEST,
-        'label': 'testing-agent',
-        'DID': my_did,
-        'DIDDoc': {
-            'key': my_vk,
-            'endpoint': config.endpoint,
-        }
-    })
+    request = Connection.Request.build(
+        'testing-agent',
+        my_did,
+        my_vk,
+        config.endpoint
+    )
 
     await transport.send(
-        invite_msg['endpoint'],
+        invite_msg['serviceEndpoint'],
         await pack(
             wallet_handle,
             my_vk,
-            invite_msg['key'],
+            invite_msg['recipient_keys'][0],
             request
         )
     )
@@ -65,21 +35,14 @@ async def test_connection_started_by_tested_agent(config, wallet_handle, transpo
     # Wait for response
     response_bytes = await expect_message(transport, 60)
 
-    response = await unpack(wallet_handle, response_bytes, expected_to_vk=my_vk)
-
-    validate_message(
-        [
-            '@type',
-            'DID',
-            'DIDDoc'
-        ],
-        response
+    response = await unpack(
+        wallet_handle,
+        response_bytes,
+        expected_to_vk=my_vk
     )
 
-    validate_message(
-        [
-            'key',
-            'endpoint'
-        ],
-        response['DIDDoc']
-    )
+    Connection.Response.validate_pre_sig(response)
+
+    response['connection'] = await unpack_and_verify_signed_field(response['connection~sig'])
+
+    Connection.Response.validate(response)


### PR DESCRIPTION
This is dependent on #64 and #67. This implements "manual" tests for connection protocol.

"Manual" tests means invite urls are copied from or pasted into the test suite to begin the protocol.