### PR TITLE
fix socket error in python example on OSX Mojave(10.14.2)

### DIFF
--- a/python/modules/admin.py
+++ b/python/modules/admin.py
@@ -67,7 +67,7 @@ class Admin(Module):
 async def root(request):
     print(request)
     agent = request.app['agent']
-    local_ip = socket.gethostbyname(socket.gethostname())
+    local_ip = socket.gethostbyname("")
     agent.offer_endpoint = request.url.scheme + '://' + local_ip
     agent.endpoint = request.url.scheme + '://' + local_ip
     if request.url.port is not None:


### PR DESCRIPTION
Signed-off-by: kukgini <kukgini@gmail.com>

on OSX Mojave, running indy-agent.py generate following error:
```
$ python indy-agent.py 8095
Configure wallet connection via UI.
===== Starting Server on: http://localhost:8095 =====
<Request GET / >
Error handling request
Traceback (most recent call last):
  File "/usr/local/lib/python3.7/site-packages/aiohttp/web_protocol.py", line 390, in start
    resp = await self._request_handler(request)
  File "/usr/local/lib/python3.7/site-packages/aiohttp/web_app.py", line 366, in _handle
    resp = await handler(request)
  File "/usr/local/lib/python3.7/site-packages/aiohttp_jinja2/__init__.py", line 91, in wrapped
    context = await coro(*args)
  File "/Users/soominlee/D/ssi/indy/indy-agent/python/modules/admin.py", line 70, in root
    local_ip = socket.gethostbyname(socket.gethostname())
socket.gaierror: [Errno 8] nodename nor servname provided, or not known
```
It is because of that OS X can not resolve the `$HOSTNAME` by default.
Anyway, This change can fix the problem. 
Can you review it?