### PR TITLE
connection_key -> pairwise metadata

### DIFF
--- a/python/modules/connection.py
+++ b/python/modules/connection.py
@@ -531,7 +531,8 @@ class Connection(Module):
                 'label': label,
                 'their_endpoint': their_endpoint,
                 'their_vk': their_vk,
-                'my_vk': my_vk
+                'my_vk': my_vk,
+                'connection_key': msg.data['connection~sig']['signer']
             })
         )
 


### PR DESCRIPTION
It's very useful to have connection_key in the pairwise metadata, such as the case for the REQUEST message handler, for the purpose of correlation the pairwise connection with the invitation on the client side. This is how the client will find its session parameters (such as my_did) associated with the particular invitation link.

Signed-off-by: Sergey Chernyshev <serge.chernyshev@gmail.com>