### PR TITLE
fix wallet_handle leak

### DIFF
--- a/python/agent.py
+++ b/python/agent.py
@@ -112,6 +112,9 @@ class Agent:
             print(e)
 
         try:
+            if self.wallet_handle:
+                await wallet.close_wallet(self.wallet_handle)
+
             self.wallet_handle = await wallet.open_wallet(
                 wallet_config,
                 wallet_credentials


### PR DESCRIPTION
When "/connect" handler is called many times subsequently with different credentials, previously opened wallet_handle is not properly closed. This leads to "no more native handles" error.