### PR TITLE
Handle multiple incoming websocket connections

### DIFF
--- a/python/websocket_message_handler.py
+++ b/python/websocket_message_handler.py
@@ -11,39 +11,46 @@ class WebSocketMessageHandler:
 
     async def ws_handler(self, request):
 
-        self.ws = web.WebSocketResponse()
-        await self.ws.prepare(request)
+        ws = web.WebSocketResponse()
+        await ws.prepare(request)
+
+        if self.ws is not None:
+            await self.ws.close()
+
+        self.ws = ws
 
         _, unfinished = await asyncio.wait(
             [
-                self._websocket_receive(),
-                self._websocket_send()
+                self._websocket_receive(ws),
+                self._websocket_send(ws)
             ],
             return_when=asyncio.FIRST_COMPLETED
         )
         for task in unfinished:
             task.cancel()
 
-        ws = self.ws
-        self.ws = None
         return ws
 
-    async def _websocket_receive(self):
-        async for websocket_message in self.ws:
+    async def _websocket_receive(self, ws):
+        async for websocket_message in ws:
             if websocket_message.type == aiohttp.WSMsgType.TEXT:
                 if websocket_message.data == 'close':
-                    await self.ws.close()
+                    await ws.close()
                 else:
                     print('Received "{}"'.format(websocket_message.data))
                     await self.recv_q.put(websocket_message.data)
             elif websocket_message.type == aiohttp.WSMsgType.ERROR:
                 print('ws connection closed with exception %s' %
-                      self.ws.exception())
+                      ws.exception())
 
         print('websocket connection closed')
 
-    async def _websocket_send(self):
+    async def _websocket_send(self, ws):
         while True:
             msg_to_send = await self.send_q.get()
+            if ws.closed:
+                # avoid sending to closed socket and route the message to concurrent instance
+                await self.send_q.put(msg_to_send)
+                break
             print('Sending "{}"'.format(msg_to_send))
-            await self.ws.send_str(msg_to_send)
+            await ws.send_str(msg_to_send)


### PR DESCRIPTION
- make each instance of _websocket_send()/_receive() to work with the same WebSocketResponse object
- inform the client when an incoming WS request takes over the connection, by closing the old socket
- instance of _websocket_send() of the old WS connection, could consume an outgoing message belonging to the new connection

Signed-off-by: Sergey Chernyshev <serge.chernyshev@gmail.com>